### PR TITLE
Add InnerSource mailing list references to InnerSource SIG repo

### DIFF
--- a/.github/ISSUE_TEMPLATE/meeting-minutes.md
+++ b/.github/ISSUE_TEMPLATE/meeting-minutes.md
@@ -49,3 +49,6 @@ _day-of-week_ DD MMM yyyy - _time_ EST / _time_ UK
 - Meeting number: 
 - Password:
 - Call-in:
+
+### Mailing List
+Email innersource+subscribe@finos.org to subscribe to the InnerSource SIG mailing list.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ Please follow https://odp.finos.org/docs/project-collaboration/#finos-project-bl
 ## Governance
 This blueprint implements https://github.com/finos/community/tree/master/governance#open-source-software-projects
 
+
+## Mailing List
+Email innersource+subscribe@finos.org to subscribe to the InnerSource SIG mailing list.
+
 ## License
 
 Copyright 2019 Fintech Open Source Foundation


### PR DESCRIPTION
## Description
This PR adds InnerSource SIG mailing list references to the repo `README.md` and `.github/ISSUE_TEMPLATE/meeting-minutes.md` so community members can subscribe for SIG updates.

## Added Markdown
```
### Mailing List
Email innersource+subscribe@finos.org to subscribe to the InnerSource SIG mailing list.
```

## Markdown Preview

### Mailing List
Email innersource+subscribe@finos.org to subscribe to the InnerSource SIG mailing list.
