### PR TITLE
Add InnerSource Logo to InnerSource SIG README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img src="https://github.com/finos/branding/blob/master/sig-logos/innersource-sig/Horizontal/2020_InnerSourceSIG_Horizontal.png" width="400">
+<img src="https://github.com/finos/branding/blob/master/sig-logos/innersource-sig/Horizontal/2020_InnerSourceSIG_Horizontal.png" width="600">
 
 # FINOS InnerSource Special Interest Group
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+<img src="https://github.com/finos/branding/blob/master/sig-logos/innersource-sig/Horizontal/2020_InnerSourceSIG_Horizontal.png" width="400">
+
 # FINOS InnerSource Special Interest Group
 
 InnerSource can help break down silos, encourage internal collaboration and innovation, accelerate new engineer on-boarding, and identify opportunities to contribute software back to the open source world.


### PR DESCRIPTION
## Description
This pull request adds the FINOS InnerSource SIG logo to the special interest group `README.md`.

## Markdown Added
```
<img src="https://github.com/finos/branding/blob/master/sig-logos/innersource-sig/Horizontal/2020_InnerSourceSIG_Horizontal.png" width="600">
```

## Commits 
- add innersource sig logo to README 21b0ed9
- update logo width to 600px 0b3867a