### PR TITLE
Roderick Randolph as Capital One InnerSource SIG Co-Lead

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ The InnerSource SIG target audience are individuals responsible for InnerSource 
 Name | Firm | Role
 :--- | :--- | :---
 Daniela Zheleva | Deutsche Bank | SIG Lead
-Roderick Randolph | Capital One | SIG Co-Lead
 Arthur Maltson | Capital One | SIG Co-Lead
 Clare Dillon | InnerSource Commons | SIG Secretary
 Aaron Searle | Morgan Stanley | SIG Leadership  Committee


### PR DESCRIPTION
## Description

This pull request removes Roderick Randolph as Capital One InnerSource SIG Co-Lead from the InnerSource SIG repo `README.md`