### PR TITLE
Add a new pipeline GitHub Action

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -1,0 +1,14 @@
+name: pipeline
+on: [pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '16'
+      - run: npm ci
+      - name: Lint - Markdown
+        run: npm run lint

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ note to innersource+subscribe@finos.org.
    and [Community Code of Conduct](https://www.finos.org/code-of-conduct)
 1. Make your changes on the fork. Ensure any documentation and code changes are
    formatted correctly by executing `npm run fmt` (see below for setup
-   instructions).
+   instructions). If `npm run fmt` isn't executed, the build will fail.
 1. Commit your changes (git commit -am 'Add some fooBar')
 1. Push to the branch (git push origin feature/fooBar)
 1. Create a new Pull Request


### PR DESCRIPTION
This PR continues on the work for #41 by ensuring the Markdown documents
_always_ stay formatted by introducing a new GitHub Action to validate the
Markdown files by executing the `npm lint` command. This will run `prettier
--check` which returns a non-zero status code if any of the files are not
formatted correctly.

Note: This needs to be merged after #41 is merged and this is rebased.
