### PR TITLE
Begin converting the organization maturity matrix

### DIFF
--- a/docs/maturity-matrix/README.md
+++ b/docs/maturity-matrix/README.md
@@ -1,0 +1,55 @@
+# InnerSource Maturity Matrix
+
+## Overview
+
+This document is based upon the Maturity Model InnerSourcePattern available from
+[InnerSourceCommons.org](InnerSourceCommons.org) and is licensed under a
+[Creative Commons Attribution-ShareAlike 4.0 International License](https://patterns.innersourcecommons.org/p/maturity-model)
+
+This document also contains input from the
+[FINOS InnerSource SIG meeting held in April 2021](finos/InnerSource#10). This
+is intended as a working document for the FINOS InnerSource SIG to build upon as
+they work towards producing an InnerSource maturity matrix for the Financial
+Services sector.
+
+## Purpose
+
+The purpose of the InnerSource Maturity Matrix Tool is to assess the InnerSource
+health for an organization.
+
+### Definitions
+
+- **Level 0**: Accidental - individual initiatives
+- **Level 1**: Exploration - let's try this
+- **Level 2**: Adoption - corporate support
+- **Level 3**: Efficient - widely adopted
+
+## Contributing
+
+Please use this Markdown document to collaborate on creating a comprehensive
+InnerSource maturity matrix. Please open an issue to provide comments, to ask
+questions, or to make modifications. After opening the issue, you can make a
+Pull Request with the modification.
+
+### Thank you
+
+Thank you to all the people that contributed to the creation of this document:
+
+- Daniel Izquierdo Cortazar @dicortazar
+- Isabel Drost-Fromm @MaineC
+- Jorge Nerea
+- Sebastian Spier @spier
+- Johannes Tigges @lenucksi
+- Nick Schonning @nschonni
+- Willem Jiang @WillemJiang
+- David Terol @dterol23
+- Danese Cooper @Danese
+- Clare Dillon @claredillon
+- Cristina Coffey @clcoffey
+- Robert Underwood @brooklynrob
+- Arthur Maltson @amaltson
+- Ludmila @Ludmila-N
+- James McLeod @mcleo-d
+- Daniela Zheleva @daniela-g-zheleva-db
+- Elspeth Minty
+- James McGovern

--- a/docs/maturity-matrix/organization-maturity-matrix.md
+++ b/docs/maturity-matrix/organization-maturity-matrix.md
@@ -1,85 +1,29 @@
-# InnerSource Maturity Matrix for Organizations
+# Organization Maturity Matrix
 
-## Overview
+## Transparency
 
-This document is based upon the Maturity Model InnerSourcePattern available from
-[InnerSourceCommons.org](InnerSourceCommons.org) and is licensed under a
-[Creative Commons Attribution-ShareAlike 4.0 International License](https://patterns.innersourcecommons.org/p/maturity-model)
-
-This document also contains input from the
-[FINOS InnerSource SIG meeting held in April 2021](finos/InnerSource#10). This
-is intended as a working document for the FINOS InnerSource SIG to build upon as
-they work towards producing an InnerSource maturity matrix for the Financial
-Services sector.
-
-## Purpose
-
-The purpose of the InnerSource Maturity Matrix Tool is to assess the InnerSource
-health for an organization.
-
-### Definitions
-
-- **Level 0**: Accidental - individual initiatives
-- **Level 1**: Exploration - let's try this
-- **Level 2**: Adoption - corporate support
-- **Level 3**: Efficient - widely adopted
-
-## Organization Maturity Matrix
-
-### Transparency
-
-#### Plans & Products - Level 0
+### Plans & Products - Level 0
 
 - Individuals and teams do not regularly disclose their plans or products to
   multiple stakeholders.
 - No formal actions exists at the organization.
 
-#### Plans & Products - Level 1
+### Plans & Products - Level 1
 
 - Individuals and teams give visibility to their plans or products to multiple
   stakeholders, before they are started.
 - Shared roadmap.
 
-#### Plans & Products - Level 2
+### Plans & Products - Level 2
 
 - There are already shared roadmaps with clear guidelines and contribution rules
   where stakeholders can provide feedback.
 - However this is not standardized across the organization and not all of the
   projects provide this info.
 
-#### Plans & Products - Level 3
+### Plans & Products - Level 3
 
 - Roadmaps are shared by default and there is a standard process and homogeneous
   way to do this across the organization at the level of each InnerSource
   project.
 - This contains clear rules to contribute and influence in the roadmap.
-
-## Contributing
-
-Please use this Markdown document to collaborate on creating a comprehensive
-InnerSource maturity matrix. Please open an issue to provide comments, to ask
-questions, or to make modifications. After opening the issue, you can make a
-Pull Request with the modification.
-
-### Thank you
-
-Thank you to all the people that contributed to the creation of this document:
-
-- Daniel Izquierdo Cortazar @dicortazar
-- Isabel Drost-Fromm @MaineC
-- Jorge Nerea
-- Sebastian Spier @spier
-- Johannes Tigges @lenucksi
-- Nick Schonning @nschonni
-- Willem Jiang @WillemJiang
-- David Terol @dterol23
-- Danese Cooper @Danese
-- Clare Dillon @claredillon
-- Cristina Coffey @clcoffey
-- Robert Underwood @brooklynrob
-- Arthur Maltson @amaltson
-- Ludmila @Ludmila-N
-- James McLeod @mcleo-d
-- Daniela Zheleva @daniela-g-zheleva-db
-- Elspeth Minty
-- James McGovern

--- a/docs/maturity-matrix/organization-maturity-matrix.md
+++ b/docs/maturity-matrix/organization-maturity-matrix.md
@@ -17,6 +17,43 @@ Services sector.
 The purpose of the InnerSource Maturity Matrix Tool is to assess the InnerSource
 health for an organization.
 
+### Definitions
+
+- **Level 0**: Accidental - individual initiatives
+- **Level 1**: Exploration - let's try this
+- **Level 2**: Adoption - corporate support
+- **Level 3**: Efficient - widely adopted
+
+## Organization Maturity Matrix
+
+### Transparency
+
+#### Plans & Products - Level 0
+
+- Individuals and teams do not regularly disclose their plans or products to
+  multiple stakeholders.
+- No formal actions exists at the organization.
+
+#### Plans & Products - Level 1
+
+- Individuals and teams give visibility to their plans or products to multiple
+  stakeholders, before they are started.
+- Shared roadmap.
+
+#### Plans & Products - Level 2
+
+- There are already shared roadmaps with clear guidelines and contribution rules
+  where stakeholders can provide feedback.
+- However this is not standardized across the organization and not all of the
+  projects provide this info.
+
+#### Plans & Products - Level 3
+
+- Roadmaps are shared by default and there is a standard process and homogeneous
+  way to do this across the organization at the level of each InnerSource
+  project.
+- This contains clear rules to contribute and influence in the roadmap.
+
 ## Contributing
 
 Please use this Markdown document to collaborate on creating a comprehensive

--- a/docs/maturity-matrix/organization-maturity-matrix.md
+++ b/docs/maturity-matrix/organization-maturity-matrix.md
@@ -1,0 +1,48 @@
+# InnerSource Maturity Matrix for Organizations
+
+## Overview
+
+This document is based upon the Maturity Model InnerSourcePattern available from
+[InnerSourceCommons.org](InnerSourceCommons.org) and is licensed under a
+[Creative Commons Attribution-ShareAlike 4.0 International License](https://patterns.innersourcecommons.org/p/maturity-model)
+
+This document also contains input from the
+[FINOS InnerSource SIG meeting held in April 2021](finos/InnerSource#10). This
+is intended as a working document for the FINOS InnerSource SIG to build upon as
+they work towards producing an InnerSource maturity matrix for the Financial
+Services sector.
+
+## Purpose
+
+The purpose of the InnerSource Maturity Matrix Tool is to assess the InnerSource
+health for an organization.
+
+## Contributing
+
+Please use this Markdown document to collaborate on creating a comprehensive
+InnerSource maturity matrix. Please open an issue to provide comments, to ask
+questions, or to make modifications. After opening the issue, you can make a
+Pull Request with the modification.
+
+### Thank you
+
+Thank you to all the people that contributed to the creation of this document:
+
+- Daniel Izquierdo Cortazar @dicortazar
+- Isabel Drost-Fromm @MaineC
+- Jorge Nerea
+- Sebastian Spier @spier
+- Johannes Tigges @lenucksi
+- Nick Schonning @nschonni
+- Willem Jiang @WillemJiang
+- David Terol @dterol23
+- Danese Cooper @Danese
+- Clare Dillon @claredillon
+- Cristina Coffey @clcoffey
+- Robert Underwood @brooklynrob
+- Arthur Maltson @amaltson
+- Ludmila @Ludmila-N
+- James McLeod @mcleo-d
+- Daniela Zheleva @daniela-g-zheleva-db
+- Elspeth Minty
+- James McGovern


### PR DESCRIPTION
This PR starts the process of converting the Excel based InnerSource Maturity Matrix into a Markdown document. Per discussion and agreement in #46, we're going to try a flat file approach to representing the maturity matrix.

This PR starts with the Organization InnerSource Maturity Matrix. It merges the Overview section into the document, with the Matrix itself in the middle of the document.
