### PR TITLE
Updating link to 'FINOS Website' in footer menu

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -73,7 +73,7 @@ module.exports = {
           items: [
             {
               label: 'FINOS Website',
-              to: 'https://regulationinnovation.org/air-events/',
+              to: 'https://finos.org',
             },
             {
               label: 'Community Handbook',


### PR DESCRIPTION
The currently link https://regulationinnovation.org/air-events did not make sense to me.
Probably should point to https://finos.org instead?

Also some questions about the same are of the website:

* [Community Handbook](https://finosfoundation.atlassian.net/wiki/spaces/FINOS/pages/80642059/Community+Handbook) is not accessible for me
* [Community Governance](https://finosfoundation.atlassian.net/wiki/spaces/FINOS/pages/75530783/Community+Governance) seems to point to outdated content
