### PR TITLE
Update InnerSource Microsite Footer Links

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -76,8 +76,8 @@ module.exports = {
               to: 'https://regulationinnovation.org/air-events/',
             },
             {
-              label: 'Community Handbook',
-              to: 'https://finosfoundation.atlassian.net/wiki/spaces/FINOS/pages/80642059/Community+Handbook',
+              label: 'Community Microsite',
+              to: 'https://community.finos.org/docs/journey/learn',
             },
             {
               label: 'Community Governance',

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -81,7 +81,7 @@ module.exports = {
             },
             {
               label: 'Community Governance',
-              to: 'https://finosfoundation.atlassian.net/wiki/spaces/FINOS/pages/75530783/Community+Governance',
+              to: 'https://community.finos.org/docs/governance/',
             }
           ]
         },


### PR DESCRIPTION
## Description 
This pull request fixes the deprecated footer links that have been raised in #77 by linking to the updated FINOS `Community Microsite` and `Community Governance` pages.

### Footer Link Updates

`docusaurus.config.js` changes ...

```
{
  label: 'Community Microsite',
  to: 'https://community.finos.org/docs/journey/learn',
},
{
  label: 'Community Governance',
  to: 'https://community.finos.org/docs/governance/',
}
```